### PR TITLE
Get rid of Busy-waiting #4

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="VcsDirectoryMappings" defaultProject="true" />
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
 </project>

--- a/src/main/java/org/example/progresstracker/Main.java
+++ b/src/main/java/org/example/progresstracker/Main.java
@@ -31,7 +31,7 @@ public class Main {
 
             sendRepeatedMessage(jda); // the daily message method, maybe a more suitable method name later
             jda.addEventListener(new EventListener()); // listens to user interaction events from the server
-            System.out.println("Day: "+calculateDateDiff());
+
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -68,7 +68,7 @@ public class Main {
         return Duration.between(now, nextRun).getSeconds();//returning the time difference between now vs the give time the daily message needs to be send
     }
 
-    private static long calculateDateDiff() {
+    private static long calculateDateDiff() {//using this function instead of using atomic integer and increment
         LocalDate startDate = LocalDate.parse("2025-03-15"); // start date of this bot
         return ChronoUnit.DAYS.between(startDate, LocalDateTime.now()); // calculates the days since startDate by retrieving today's date
     }

--- a/src/main/java/org/example/progresstracker/Main.java
+++ b/src/main/java/org/example/progresstracker/Main.java
@@ -6,7 +6,9 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -15,8 +17,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class Main {
     private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-    private static final AtomicInteger daysCount = new AtomicInteger(17); // Initial count
-
     public static void main(String[] args) {
         runBot();
     }
@@ -31,7 +31,7 @@ public class Main {
 
             sendRepeatedMessage(jda); // the daily message method, maybe a more suitable method name later
             jda.addEventListener(new EventListener()); // listens to user interaction events from the server
-
+            System.out.println("Day: "+calculateDateDiff());
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -47,7 +47,7 @@ public class Main {
             throw new IllegalArgumentException("Channel not found!");
         }
 
-        Runnable task = () -> dailyAchievementChannel.sendMessage("Day: "+daysCount.getAndIncrement()).queue();
+        Runnable task = () -> dailyAchievementChannel.sendMessage("Day: "+calculateDateDiff()).queue();
 
         long initialDelay = getInitialDelay(8, 0); // Schedule at 8:00 AM
         long period = 24 * 60 * 60; // 24 hours in seconds
@@ -66,5 +66,10 @@ public class Main {
         }
 
         return Duration.between(now, nextRun).getSeconds();//returning the time difference between now vs the give time the daily message needs to be send
+    }
+
+    private static long calculateDateDiff() {
+        LocalDate startDate = LocalDate.parse("2025-03-15"); // start date of this bot
+        return ChronoUnit.DAYS.between(startDate, LocalDateTime.now()); // calculates the days since startDate by retrieving today's date
     }
 }

--- a/src/main/java/org/example/progresstracker/Main.java
+++ b/src/main/java/org/example/progresstracker/Main.java
@@ -7,14 +7,13 @@ import net.dv8tion.jda.api.requests.GatewayIntent;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class Main {
-
-    private static final String DAILY_ACHIEVEMENT_CHANNEL_ID = "1351566846624534559"; //Add your channel ID here
     private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
     private static final AtomicInteger daysCount = new AtomicInteger(8); // Initial count
 
@@ -39,7 +38,10 @@ public class Main {
     }
 
     private static void sendRepeatedMessage(JDA jda) {
-        TextChannel dailyAchievementChannel = jda.getTextChannelById(DAILY_ACHIEVEMENT_CHANNEL_ID); //update your channel ID in CHANNEL_ID variable
+
+        List<TextChannel> channels = jda.getTextChannelsByName("daily-achievement", true);
+
+        TextChannel dailyAchievementChannel = channels.get(0);
 
         if (dailyAchievementChannel == null) {//If the channel does not exist, it throws the error
             throw new IllegalArgumentException("Channel not found!");

--- a/src/main/java/org/example/progresstracker/Main.java
+++ b/src/main/java/org/example/progresstracker/Main.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class Main {
     private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-    private static final AtomicInteger daysCount = new AtomicInteger(8); // Initial count
+    private static final AtomicInteger daysCount = new AtomicInteger(17); // Initial count
 
     public static void main(String[] args) {
         runBot();

--- a/src/main/java/org/example/progresstracker/Main.java
+++ b/src/main/java/org/example/progresstracker/Main.java
@@ -2,8 +2,6 @@ package org.example.progresstracker;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageHistory;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 
@@ -49,7 +47,7 @@ public class Main {
 
         Runnable task = () -> dailyAchievementChannel.sendMessage("Day: "+daysCount.getAndIncrement()).queue();
 
-        long initialDelay = getInitialDelay(0, 25); // Schedule at 8:00 AM
+        long initialDelay = getInitialDelay(8, 0); // Schedule at 8:00 AM
         long period = 24 * 60 * 60; // 24 hours in seconds
 
         scheduler.scheduleAtFixedRate(task, initialDelay, period, TimeUnit.SECONDS); // Execute task after specific interval of time


### PR DESCRIPTION
Closes #4

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] Made sure that this does not break anything else.

## Brief explanation of code functionality
This update improves the **daily message scheduling system** by removing **busy-waiting** and ensuring efficient execution.  

## **🔹 Key Changes & Improvements:**  
1. **Replaces `Thread.sleep(n)` with `ScheduledExecutorService`**  
   - Uses `scheduleAtFixedRate` to send a message at **8:00 AM daily** without blocking the thread.  
   
2. **Calculates Initial Delay Dynamically**  
   - `getInitialDelay(hour, minute)` ensures the bot schedules correctly, even if restarted later in the day.  

3. **Fails Fast if the Channel Is Not Found**  
   - Throws an `IllegalArgumentException` if the bot cannot locate the configured Discord channel.  

4. **Ensures Non-Blocking Execution**  
   - Uses a **single-threaded scheduler** to execute tasks efficiently without keeping the bot in a busy state.  

---

### **✅ Expected Behavior:**  
- The bot will **send a message at exactly 8:00 AM every day**.  
- The **thread is efficiently released** when idle, preventing unnecessary CPU usage.  
- The **day count auto-increments** after each message.  

This PR **eliminates busy-waiting** while keeping the bot responsive and efficient. 
